### PR TITLE
Error checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 GetWindowID
+
+*.m~

--- a/GetWindowID.m
+++ b/GetWindowID.m
@@ -1,11 +1,16 @@
+//2014Jul22: added error message when fewer than two parameters (sahi1l)
 #include <Cocoa/Cocoa.h>
 #include <CoreGraphics/CGWindow.h>
 
 int main(int argc, char **argv)
 {
-	NSArray *windows = (NSArray *)CGWindowListCopyWindowInfo(kCGWindowListExcludeDesktopElements,kCGNullWindowID);
-	for(NSDictionary *window in windows)
-		if ([[window objectForKey:(NSString *)kCGWindowOwnerName] isEqualToString:[NSString stringWithUTF8String:argv[1]]])
-			if ([[window objectForKey:(NSString *)kCGWindowName] isEqualToString:[NSString stringWithUTF8String:argv[2]]])
-				printf("%d\n", [[window objectForKey:(NSString *)kCGWindowNumber] intValue]);
+    if(argc<=2){
+        fprintf(stderr,"Usage: %s <application-bundle-name> <window-title>\n",argv[0]);
+        return -1;
+    }
+    NSArray *windows = (NSArray *)CGWindowListCopyWindowInfo(kCGWindowListExcludeDesktopElements,kCGNullWindowID);
+    for(NSDictionary *window in windows)
+        if ([[window objectForKey:(NSString *)kCGWindowOwnerName] isEqualToString:[NSString stringWithUTF8String:argv[1]]])
+            if ([[window objectForKey:(NSString *)kCGWindowName] isEqualToString:[NSString stringWithUTF8String:argv[2]]])
+                printf("%d\n", [[window objectForKey:(NSString *)kCGWindowNumber] intValue]);
 }


### PR DESCRIPTION
If there are fewer than two arguments, return a usage statement instead of a complicated Objective-Cish error.
